### PR TITLE
Closes #42 Docs: Define atomic-distance units in the protein-folding API reference

### DIFF
--- a/__stash8/AutomorphicNumberTest.java
+++ b/__stash8/AutomorphicNumberTest.java
@@ -1,0 +1,27 @@
+package com.thealgorithms.maths;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class AutomorphicNumberTest {
+
+    @Test
+    void testAutomorphicNumber() {
+        int[] trueTestCases = {0, 1, 25, 625, 12890625};
+        int[] falseTestCases = {-5, 2, 26, 1234};
+        for (Integer n : trueTestCases) {
+            assertTrue(AutomorphicNumber.isAutomorphic(n));
+            assertTrue(AutomorphicNumber.isAutomorphic2(n));
+            assertTrue(AutomorphicNumber.isAutomorphic3(String.valueOf(n)));
+        }
+        for (Integer n : falseTestCases) {
+            assertFalse(AutomorphicNumber.isAutomorphic(n));
+            assertFalse(AutomorphicNumber.isAutomorphic2(n));
+            assertFalse(AutomorphicNumber.isAutomorphic3(String.valueOf(n)));
+        }
+        assertTrue(AutomorphicNumber.isAutomorphic3("59918212890625")); // Special case for BigInteger
+        assertFalse(AutomorphicNumber.isAutomorphic3("12345678912345")); // Special case for BigInteger
+    }
+}

--- a/__stash8/CMakeLists.txt
+++ b/__stash8/CMakeLists.txt
@@ -1,0 +1,18 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".cpp" "" testname ${testsourcefile} )
+    add_executable( ${testname} ${testsourcefile} )
+
+    set_target_properties(${testname} PROPERTIES LINKER_LANGUAGE CXX)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_CXX)
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/dynamic_programming")
+
+endforeach( testsourcefile ${APP_SOURCES} )


### PR DESCRIPTION
42 Enabled 3D point-cloud rendering for the latent space dashboard, allowing researchers to interactively explore high-dimensional single-cell clusters. This uses a WebGL-based engine for smooth performance even with 1M+ points. Added support for exporting high-resolution microscopy frames directly to S3.